### PR TITLE
Improve Gitlab support

### DIFF
--- a/src/main/java/jetbrains/buildServer/auth/oauth/OAuthAuthenticationScheme.java
+++ b/src/main/java/jetbrains/buildServer/auth/oauth/OAuthAuthenticationScheme.java
@@ -23,7 +23,7 @@ public class OAuthAuthenticationScheme extends HttpAuthenticationSchemeAdapter {
     private static final Logger LOG = Logger.getLogger(OAuthAuthenticationScheme.class);
     public static final String CODE = "code";
     public static final String STATE = "state";
-    public static final String[] IDS_LIST = new String[]{"login", "name"};
+    public static final String[] IDS_LIST = new String[]{"login", "username", "name"};
 
     private final PluginDescriptor pluginDescriptor;
     private final ServerPrincipalFactory principalFactory;


### PR DESCRIPTION
To create users in TeamCity that match those returned by Gitlab, it's necessary to use the "username" property of the API response, rather than "name".  This PR adds "username" to the list of properties through which to search.  