### PR TITLE
Only allow users from a specified domain

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -7,20 +7,19 @@ image:./docs/login-screen.png[Login Screen]
 = Installation
 
 Grab latest version of plugin from link image:https://api.bintray.com/packages/pwielgolaski/generic/teamcity-oauth/images/download.svg[link="https://bintray.com/pwielgolaski/generic/teamcity-oauth/_latestVersion"]
-
 and install it to Teamcity following https://confluence.jetbrains.com/display/TCD10/Installing+Additional+Plugins[https://confluence.jetbrains.com/display/TCD10/Installing+Additional+Plugins]
 
 = Configuration
 
 Plugin support authentication using:
 
-* github
-* bitbucket
-* google
-* custom oAuth server.
+* GitHub
+* Bitbucket
+* Google
+* any custom oAuth server
 
 
-If you want to use github you need an application to be created https://github.com/settings/applications/new[https://github.com/settings/applications/new]. `Authorization callback URL` should be homepage of TC.
+If you want to use GitHub you need an application to be created https://github.com/settings/applications/new[https://github.com/settings/applications/new]. `Authorization callback URL` should be homepage of TC.
 
 Login as administrator and go to Administration &gt; Authentication
 
@@ -28,11 +27,13 @@ Switch to advanced mode and add module HTTP-OAUTH.v2.
 
 image:./docs/config-screen.png[Configuration Screen]
 
-You need to specify your client id and client secret.
-Also you need to specific scope, `user` is fine for github, 'account' for bitbucket.
+You need to specify your client id, client secret and scope.
+For GitHub, `user` scope is appropriate, `account` for Bitbucket, and `profile email` for Google.
 
-If you dont choose "Allow creating new users on the first login" only users that already exists in Teamcity can login.
+If you don't enable "Allow creating new users on the first login" only users that already exist in Teamcity can login.
 It means that you need account with the same name as user login name in oauth.
+
+If you specify an "Email Domain", only users whose email is at that domain will be able to log in.
 
 You can decide if you want to hide user/password form on login screen (worth leaving unchecked when you test it).
 

--- a/src/main/java/jetbrains/buildServer/auth/oauth/AuthenticationSchemeProperties.java
+++ b/src/main/java/jetbrains/buildServer/auth/oauth/AuthenticationSchemeProperties.java
@@ -62,6 +62,11 @@ public class AuthenticationSchemeProperties {
         return getProperty(ConfigKey.scope);
     }
 
+    @Nullable
+    public String getEmailDomain() {
+        return getProperty(ConfigKey.emailDomain);
+    }
+
     public boolean isHideLoginForm() {
         return Boolean.valueOf(getProperty(ConfigKey.hideLoginForm));
     }

--- a/src/main/java/jetbrains/buildServer/auth/oauth/ConfigKey.java
+++ b/src/main/java/jetbrains/buildServer/auth/oauth/ConfigKey.java
@@ -10,5 +10,6 @@ public enum ConfigKey {
     clientSecret,
     scope,
     hideLoginForm,
-    allowInsecureHttps
+    allowInsecureHttps,
+    emailDomain
 }

--- a/src/main/java/jetbrains/buildServer/auth/oauth/PluginConfiguration.java
+++ b/src/main/java/jetbrains/buildServer/auth/oauth/PluginConfiguration.java
@@ -47,8 +47,9 @@ public class PluginConfiguration {
     public OAuthAuthenticationScheme oAuthAuthenticationScheme(LoginConfiguration loginConfiguration,
                                                         PluginDescriptor pluginDescriptor,
                                                         ServerPrincipalFactory principalFactory,
-                                                        OAuthClient authClient) {
-        OAuthAuthenticationScheme authenticationScheme = new OAuthAuthenticationScheme(pluginDescriptor, principalFactory, authClient);
+                                                        OAuthClient authClient,
+                                                        AuthenticationSchemeProperties schemeProperties) {
+        OAuthAuthenticationScheme authenticationScheme = new OAuthAuthenticationScheme(pluginDescriptor, principalFactory, authClient, schemeProperties);
         loginConfiguration.registerAuthModuleType(authenticationScheme);
         return authenticationScheme;
     }

--- a/src/main/java/jetbrains/buildServer/auth/oauth/ServerPrincipalFactory.java
+++ b/src/main/java/jetbrains/buildServer/auth/oauth/ServerPrincipalFactory.java
@@ -40,7 +40,7 @@ public class ServerPrincipalFactory {
         }
     }
 
-    @Nullable
+    @NotNull
     private Optional<ServerPrincipal> findExistingPrincipal(@NotNull final String userName) {
         try {
             final SUser user = userModel.findUserByUsername(userName, PluginConstants.ID_USER_PROPERTY_KEY);

--- a/src/main/resources/buildServerResources/editOAuthSchemeProperties.jsp
+++ b/src/main/resources/buildServerResources/editOAuthSchemeProperties.jsp
@@ -75,6 +75,11 @@
     <span class="grayNote">OAuth scope of this TeamCity server.</span>
 </div>
 <div>
+    <label for="<%=ConfigKey.emailDomain%>">Email Domain:</label><br/>
+    <prop:textProperty style="width: 100%;" name="<%=ConfigKey.emailDomain.toString()%>"/><br/>
+    <span class="grayNote">Authorize only users with emails at this domain (optional).</span>
+</div>
+<div>
     <prop:checkboxProperty uncheckedValue="false" name="<%=ConfigKey.hideLoginForm.toString()%>"/>
     <label for="<%=ConfigKey.hideLoginForm%>">Hide login form</label><br/>
     <span class="grayNote">Hide user/password login form on Teamcity login page.</span>


### PR DESCRIPTION
I'm using this plugin with Google as the OAuth provider, but only want to allow users from my organization into TeamCity.

This basically matches the `--email-domain` option from https://github.com/bitly/oauth2_proxy.